### PR TITLE
VLC supports flv files too

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -5666,7 +5666,7 @@ These will come at the end or right before the file name, if any."
   ;; matches that of some potentially supported format.
   :matcher '((local-file "file:" "http:" "ftp:")
              "ogg" "flac" "mp3" "m4a" "mka" "wav" "wma"
-             "mpg" "mpeg" "vob" "avi" "ogm" "mp4" "m4v" "mkv"
+             "mpg" "mpeg" "vob" "avi" "ogm" "mp4" "m4v" "mkv" "flv"
              "mov" "asf" "wmv" "rm" "rmvb" "ts")
 
   ;; Play special media URIs regardless of the file name.


### PR DESCRIPTION
At least on my debian testing system VLC media player 2.2.0-pre4 Weatherwax (revision 2.2.0-pre3-104-g836a443) supports .flv files just fine.
