### PR TITLE
Update bongo.el

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -5948,11 +5948,12 @@ These will come at the end or right before the file name, if any."
   (when (executable-find bongo-mplayer-program-name)
     (let ((result nil))
       (with-temp-buffer
-        (call-process bongo-mplayer-program-name nil t nil
-                      (ecase type
-                        (audio "-ao")
-                        (video "-vo"))
-                      "help")
+        (let ((process-environment (push "LC_ALL=C" process-environment)))
+          (call-process bongo-mplayer-program-name nil t nil
+                        (ecase type
+                          (audio "-ao")
+                          (video "-vo"))
+                        "help"))
         (goto-char (point-min))
         (search-forward (concat "Available " (ecase type
                                                (audio "audio")


### PR DESCRIPTION
This change fixes the bongo failure starting in a non-English locale.

The function expects the answer "Available audio output drivers:" from the MPlayer, but when the current locale is not English, the function is failed. It is actual to force the standard English locale here.