### PR TITLE
Fix 'bongo-file-name-matches-p' to correctly extract value-matcher

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -4496,7 +4496,7 @@ If it is a list of strings, treat it as a set of file name extensions;
   return non-nil if the extension of FILE-NAME appears in VALUE-MATCHER.
 Otherwise, signal an error."
   (let ((type-matcher (car matcher))
-        (value-matcher (cdr matcher)))
+        (value-matcher (cadr matcher)))
     (when (let* ((uri-scheme (bongo-uri-scheme file-name))
                  (needed-type-matcher
                   (if uri-scheme


### PR DESCRIPTION
Earlier cdr was used to extract value-matcher from matcher, as a result
the value-matcher extracted was always a list leading to incorrect
behaviour. cadr is used now used to extract the value-matcher