### PR TITLE
Start vlc with '--play-and-stop' argument

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -5940,7 +5940,7 @@ These will come at the end or right before the file name, if any."
          (arguments (append
                      (when bongo-vlc-interactive
                        (append (list "-I" "rc" "--rc-fake-tty"
-                                     "--play-and-exit")
+                                     "--play-and-stop" "--play-and-exit")
                                (when (bongo-uri-p file-name)
                                  (list "-vv"))
                                (when (eq window-system 'w32)


### PR DESCRIPTION
It seems, on newer VLC versions without the argument '--play-and-stop' the media keeps playing not allowing bongo to switch to next track. Older versions of VLC work irrespective of whether this flag is passed (I have tested it on v2.0.8 of VLC)

Fixes #23 