### PR TITLE
Fix status handling for VLC

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -5843,6 +5843,18 @@ These will come at the end or right before the file name, if any."
                         (rx (and line-start
                                  "status change:"
                                  (zero-or-more (or space "("))
+                                 "audio volume:"
+                                 (zero-or-more space)
+                                 (submatch (one-or-more digit))
+                                 (zero-or-more (or space ")"))
+                                 line-end))))
+                     (when (null (bongo-player-get player 'timer))
+                       (bongo-vlc-player-start-timer player)))
+                    ((looking-at
+                      (eval-when-compile
+                        (rx (and line-start
+                                 "status change:"
+                                 (zero-or-more (or space "("))
                                  "play state:"
                                  (zero-or-more space)
                                  (submatch (one-or-more digit))
@@ -5937,7 +5949,7 @@ These will come at the end or right before the file name, if any."
   (let* ((process-connection-type nil)
          (arguments (append
                      (when bongo-vlc-interactive
-                       (append (list "-I" "rc" "--rc-fake-tty"
+                       (append (list "-I" "oldrc" "--rc-fake-tty"
                                      "--play-and-stop" "--play-and-exit")
                                (when (bongo-uri-p file-name)
                                  (list "-vv"))


### PR DESCRIPTION
VLC 2.2.0 uses a new default RC interface which is not currently handled by Bongo.  For now, use the oldrc interface to get the track information.

Preemptively get the information by looking for "audio volume" events, which are printed at the start of the program, rather than requiring the user to seek first.

---

Fixes #25.  I've done some minor testing and it appears to work properly, though I'm not super familiar with the bongo codebase.

It might be nice to pair this change with some version detection, as there might be some LTS distro which has an older version of VLC.  This would be useful even when/if the new RC interface is supported.