### PR TITLE
VLC supports .aac audio files

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -3137,6 +3137,7 @@ See `bongo-line-proposed-external-fields'."
 
 (defcustom bongo-audio-file-name-extensions
   `("669"
+    "aac",
     "amf"
     "apun"
     "au"

--- a/bongo.el
+++ b/bongo.el
@@ -5767,6 +5767,7 @@ These will come at the end or right before the file name, if any."
   ;; matches that of some potentially supported format.
   :matcher '((local-file "file:" "http:" "ftp:")
              "669"
+             "aac"
              "asf"
              "au"
              "avi"


### PR DESCRIPTION
VLC supports .aac audio files