### PR TITLE
Add URL to the package header

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -8,6 +8,7 @@
 
 ;; Version: 1.0
 ;; Package-Requires: ((cl-lib "0.5") (emacs "24.1"))
+;; URL: https://github.com/dbrock/bongo
 
 ;; This file is part of Bongo.
 


### PR DESCRIPTION
`C-h P` (`describe-package`) provides a standand way to find the
homepage of a package if the package presents URL: (or Homepage:),
this keyword is recommended by Elisp manual, see [(elisp) Simple
Packages](https://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html)