### PR TITLE
Adaptation for mpv's argument parser changes

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -6430,7 +6430,7 @@ Also fetch metadata and length of track if not fetched already."
   "Get the command line argument for starting mpv's remote interface at SOCKET-FILE."
   (when (equal bongo-mpv-remote-option 'unknown)
     (setq bongo-mpv-remote-option (bongo--mpv-get-remote-option)))
-  (list bongo-mpv-remote-option socket-file))
+  (list (concat bongo-mpv-remote-option "=" socket-file)))
 
 (defun bongo-mpv-player-pause/resume (player)
   "Play/pause mpv PLAYER."


### PR DESCRIPTION
According to this commit[0] mpv now requires an equal sign between the
parameters and their arguments.

[0]: https://github.com/mpv-player/mpv/commit/d3cef97ad38fb027262a905bd82e1d3d2549aec7