### PR TITLE
Add end space to prompt

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -10473,7 +10473,7 @@ However, setting it through Custom does this automatically."
 (defun bongo-confirm-player-stop ()
   "If the current buffer has a player running stop it before killing the buffer."
   (or (not bongo-player)
-      (when (yes-or-no-p "This buffer has an associated player running, stop it?")
+      (when (yes-or-no-p "This buffer has an associated player running, stop it? ")
         (bongo-player-stop bongo-player)
         t)))
 


### PR DESCRIPTION
This qualifies as the least impressive contribution of the year but I noticed one of the prompts was missing an end space.