### PR TITLE
Use 1s tick time for mpv

### DIFF
--- a/bongo.el
+++ b/bongo.el
@@ -6421,7 +6421,7 @@ Also fetch metadata and length of track if not fetched already."
   "Start tick timer for PLAYER."
   (bongo-mpv-player-stop-timer player)
   (let ((timer (run-with-timer bongo-mpv-initialization-period
-                               0.1
+                               1
                                'bongo-mpv-player-tick
                                player)))
     (bongo-player-put player 'timer timer)))


### PR DESCRIPTION
This is consistent with every other backends tick time. I noticed that even when my machine is idle emacs was using a fair amount of CPU. After some debugging it seemed to come from bongo-mpv-player-tick.